### PR TITLE
Não coletamos dados de localização.

### DIFF
--- a/values-pt/strings.xml
+++ b/values-pt/strings.xml
@@ -646,7 +646,7 @@
     <string name="privacy_policy_not_collect"><![CDATA[
         <p>• Nós não coletamos informações pessoais que o possam identificar. Em outras palavras, nós não coletamos informações sobre o seu nome, residência, número do telefone, endereço de e-mail, endreço IP ou endereço MAC.</p>
         <p>• Nós não coletamos informação da sua saúde pessoal, contatos e textos das notificações do seu dispositivo.</p>
-        • We do not collect location data.
+        • Não coletamos dados de localização.
     ]]></string>
 
     <string name="privacy_policy_links_title">Política de privacidade dos prestadores de serviço externos</string>


### PR DESCRIPTION
estava sem tradução.
Original
• We do not collect location data.
Tradução
• Não coletamos dados de localização.